### PR TITLE
Fix retrieve endpoint when `nrt_neigh` is equal to one

### DIFF
--- a/cbir/api/image.py
+++ b/cbir/api/image.py
@@ -85,5 +85,5 @@ async def retrieve_image(
     )
 
     return Response(
-        content=json.dumps({"filenames": filenames, "distances": distances.tolist()}),
+        content=json.dumps({"filenames": filenames, "distances": distances}),
     )

--- a/cbir/retrieval/database.py
+++ b/cbir/retrieval/database.py
@@ -119,10 +119,14 @@ class Database:
             outputs = model(inputs).cpu().numpy()
 
         distances, labels = self.index.search(outputs, nrt_neigh)
-        distances, labels = distances.squeeze(), labels.squeeze()
+        distances, labels = distances.squeeze().tolist(), labels.squeeze().tolist()
+
+        if nrt_neigh == 1:
+            distances = [distances]
+            labels = [labels]
 
         # Return only valid results
-        stop = labels.tolist().index(-1) if -1 in labels else len(labels)
+        stop = labels.index(-1) if -1 in labels else len(labels)
         filenames = [self.redis.get(str(l)).decode("utf-8") for l in labels[:stop]]
 
         return filenames, distances[:stop]

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -52,6 +52,8 @@ def test_retrieve_image() -> None:
 
     data = response.json()
 
+    assert response.status_code == 200
     assert "distances" in data
     assert "filenames" in data
-    assert response.status_code == 200
+    assert type(data["distances"]) is list
+    assert type(data["filenames"]) is list

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -55,8 +55,8 @@ def test_retrieve_one_image() -> None:
     assert response.status_code == 200
     assert "distances" in data
     assert "filenames" in data
-    assert type(data["distances"]) is list
-    assert type(data["filenames"]) is list
+    assert isinstance(data["distances"], list)
+    assert isinstance(data["filenames"], list)
     assert len(data["distances"]) == 1
     assert len(data["filenames"]) == 1
 
@@ -79,5 +79,5 @@ def test_retrieve_image() -> None:
     assert response.status_code == 200
     assert "distances" in data
     assert "filenames" in data
-    assert type(data["distances"]) is list
-    assert type(data["filenames"]) is list
+    assert isinstance(data["distances"], list)
+    assert isinstance(data["filenames"], list)

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -37,6 +37,30 @@ def test_index_image() -> None:
     assert os.path.isfile(database_settings.filename) is True
 
 
+def test_retrieve_one_image() -> None:
+    """Test image retrieval for one image."""
+
+    with open("tests/data/image.png", "rb") as image:
+        files = {"image": image.read()}
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/images/retrieve",
+            data={"nrt_neigh": "1"},
+            files=files,
+        )
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert "distances" in data
+    assert "filenames" in data
+    assert type(data["distances"]) is list
+    assert type(data["filenames"]) is list
+    assert len(data["distances"]) == 1
+    assert len(data["filenames"]) == 1
+
+
 def test_retrieve_image() -> None:
     """Test image retrieval."""
 


### PR DESCRIPTION
closes #31 